### PR TITLE
Remove redundant pip deps from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,12 @@ FROM python:2.7-slim
 
 VOLUME ["/opt/dxlmaxmindservice-config"]
 
-# Install required packages
-RUN pip install "requests" "maxminddb" "dxlbootstrap>=0.1.3" "dxlclient"
-
 # Build service
 COPY . /tmp/build
 WORKDIR /tmp/build
-RUN python ./setup.py bdist_wheel
 
-# Install service
-RUN pip install dist/*.whl
+# Install application package and its dependencies
+RUN pip install .
 
 # Cleanup build
 RUN rm -rf /tmp/build


### PR DESCRIPTION
This commit removes the lines from the Dockerfile which install
service dependencies and build a separate wheel file. The Dockerfile
instead just pip installs the current project, which installs
the service and its dependencies defined in the setup.py file.