### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/dxlmaxmindservice/app.py
+++ b/dxlmaxmindservice/app.py
@@ -126,7 +126,7 @@ class MaxMindDatabase(object):
                 raise Exception("A MaxMind license key must be specified.")
             self._license_key = license_key
             self._database_url = (
-                "http://download.maxmind.com/app/geoip_download" +
+                "https://download.maxmind.com/app/geoip_download" +
                 "?edition_id=GeoLite2-City&license_key=" +
                 license_key + "&suffix=tar.gz")
             self._download_database = True


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).